### PR TITLE
Match annotations

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,3 +9,4 @@ flake8-bugbear
 isort
 safety
 tqdm
+ipython

--- a/src/metanetx/app.py
+++ b/src/metanetx/app.py
@@ -25,6 +25,7 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 
 
 app = Flask(__name__)
+logger = logging.getLogger(__name__)
 
 
 def init_app(application):
@@ -65,3 +66,5 @@ def init_app(application):
 
     # Read the metanetx source files into memory
     data.load_metanetx_data()
+
+    logger.info("Initialization complete")

--- a/src/metanetx/data.py
+++ b/src/metanetx/data.py
@@ -50,12 +50,20 @@ class Reaction:
         """
         Match an arbitrary search string against this reaction.
 
-        Use Levenshtein Distance to match the query on ID, name or EC number.
-        Returns a number between 0 and 100, 100 being a perfect match.
+        Use Levenshtein Distance to match the query on ID (both MNX and
+        annotations), name or EC number. Returns a number between 0 and 100, 100
+        being a perfect match.
         """
         return max(
             [
                 fuzz.ratio(query, self.mnx_id),
+                # Select the highest match among all annotations
+                max(
+                    max(fuzz.ratio(query, identifier) for identifier in db)
+                    for db in self.annotation.values()
+                )
+                # Handle reactions with no annotations
+                if self.annotation else 0,
                 fuzz.partial_ratio(query, self.name),
                 fuzz.ratio(query, self.ec),
             ]

--- a/src/metanetx/schemas.py
+++ b/src/metanetx/schemas.py
@@ -21,9 +21,6 @@ from marshmallow import Schema, fields
 class SearchSchema(Schema):
     query = fields.Str(required=True)
 
-    class Meta:
-        strict = True
-
 
 class CompartmentSchema(Schema):
     mnx_id = fields.Str()


### PR DESCRIPTION
- Changes the in-memory data structure so that annotations are properties on the actual reaction objects. This means that cross-references for reactions that are not found in the metanetx db are now discarded - but these have no use anyway.
- Match logic is now encapsulated in the Reaction/Metabolite classes
- [Exact ratio](https://github.com/seatgeek/fuzzywuzzy/#simple-ratio) is used to compare the annotation identifiers to the search query